### PR TITLE
Fix checking for wrong permission name

### DIFF
--- a/src/main/java/com/songoda/epicspawners/listeners/BlockListeners.java
+++ b/src/main/java/com/songoda/epicspawners/listeners/BlockListeners.java
@@ -132,7 +132,7 @@ public class BlockListeners implements Listener {
             doLiquidRepel(block, true);
 
             if (plugin.getBlacklistHandler().isBlacklisted(player, true)
-                    || !player.hasPermission("epicspawners.place." + spawnerTier.getIdentifyingName().replace(" ", "_"))
+                    || !player.hasPermission("epicspawners.place." + spawnerTier.getSpawnerData().getIdentifyingName().replace(" ", "_"))
                     || doForceCombine(player, spawner, event)) {
                 event.setCancelled(true);
                 return;


### PR DESCRIPTION
Fixes checking for wrong permission name, for example the plugin was checking for a permission like epicspawners.place.Tier_1 instead of epicspawners.place.pig.