### PR TITLE
Fix spawners being reset when world is unloaded.

### DIFF
--- a/src/main/java/com/songoda/epicspawners/EpicSpawners.java
+++ b/src/main/java/com/songoda/epicspawners/EpicSpawners.java
@@ -32,6 +32,7 @@ import com.songoda.epicspawners.listeners.EntityListeners;
 import com.songoda.epicspawners.listeners.InteractListeners;
 import com.songoda.epicspawners.listeners.InventoryListeners;
 import com.songoda.epicspawners.listeners.SpawnerListeners;
+import com.songoda.epicspawners.listeners.WorldListeners;
 import com.songoda.epicspawners.lootables.LootablesManager;
 import com.songoda.epicspawners.player.PlayerData;
 import com.songoda.epicspawners.player.PlayerDataManager;
@@ -153,6 +154,7 @@ public class EpicSpawners extends SongodaPlugin {
         pluginManager.registerEvents(new InteractListeners(this), this);
         pluginManager.registerEvents(new InventoryListeners(), this);
         pluginManager.registerEvents(new SpawnerListeners(this), this);
+        pluginManager.registerEvents(new WorldListeners(this), this);
 
         int timeout = Settings.AUTOSAVE.getInt() * 60 * 20;
         Bukkit.getScheduler().runTaskTimerAsynchronously(this, this::saveToFile, timeout, timeout);

--- a/src/main/java/com/songoda/epicspawners/listeners/WorldListeners.java
+++ b/src/main/java/com/songoda/epicspawners/listeners/WorldListeners.java
@@ -1,0 +1,46 @@
+package com.songoda.epicspawners.listeners;
+
+import com.songoda.epicspawners.EpicSpawners;
+import com.songoda.epicspawners.spawners.spawner.PlacedSpawner;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.world.WorldLoadEvent;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Created by noahvdaa on 5/09/2021.
+ */
+public class WorldListeners implements Listener {
+
+	private final EpicSpawners plugin;
+
+	public WorldListeners(EpicSpawners plugin) {
+		this.plugin = plugin;
+	}
+
+	@EventHandler
+	public void onWorldLoad(WorldLoadEvent e) {
+		// Unload previous spawners belonging to this world.
+		for (PlacedSpawner ps : plugin.getSpawnerManager().getSpawners()) {
+			if (e.getWorld().getName().equals(ps.getWorld().getName())) {
+				plugin.getSpawnerManager().removeSpawnerFromWorld(ps);
+			}
+		}
+
+		// Load spawners back in.
+		plugin.getDataManager().getSpawners(new Consumer<Map<Location, PlacedSpawner>>() {
+			@Override
+			public void accept(Map<Location, PlacedSpawner> locationPlacedSpawnerMap) {
+				for(PlacedSpawner ps : locationPlacedSpawnerMap.values()){
+					if (e.getWorld().getName().equals(ps.getWorld().getName())) {
+						plugin.getSpawnerManager().addSpawnerToWorld(ps.getLocation(), ps);
+					}
+				}
+			}
+		});
+	}
+
+}


### PR DESCRIPTION
EpicSpawners currently resets spawners in a world when the world is reloaded. This happens because the world objects of the spawners [store a weak reference to the world](https://www.spigotmc.org/threads/location-in-yml-doesnt-work-after-world-reload.449932/#post-3869517), which gets invalidated when the world is reloaded. This PR fixes that by re-loading spawners when a world load event is fired.