### PR TITLE
Creates the command /es openshop [player/all]

### DIFF
--- a/src/main/java/com/songoda/epicspawners/EpicSpawners.java
+++ b/src/main/java/com/songoda/epicspawners/EpicSpawners.java
@@ -15,15 +15,7 @@ import com.songoda.core.hooks.HologramManager;
 import com.songoda.core.hooks.ProtectionManager;
 import com.songoda.epicspawners.blacklist.BlacklistHandler;
 import com.songoda.epicspawners.boost.BoostManager;
-import com.songoda.epicspawners.commands.CommandBoost;
-import com.songoda.epicspawners.commands.CommandChange;
-import com.songoda.epicspawners.commands.CommandEditor;
-import com.songoda.epicspawners.commands.CommandGive;
-import com.songoda.epicspawners.commands.CommandReload;
-import com.songoda.epicspawners.commands.CommandSettings;
-import com.songoda.epicspawners.commands.CommandSpawn;
-import com.songoda.epicspawners.commands.CommandSpawnerShop;
-import com.songoda.epicspawners.commands.CommandSpawnerStats;
+import com.songoda.epicspawners.commands.*;
 import com.songoda.epicspawners.database.DataManager;
 import com.songoda.epicspawners.database.migrations._1_InitialMigration;
 import com.songoda.epicspawners.database.migrations._2_AddTiers;
@@ -126,6 +118,7 @@ public class EpicSpawners extends SongodaPlugin {
         this.commandManager.addMainCommand("es")
                 .addSubCommands(
                         new CommandGive(this),
+                        new CommandOpenShop(this),
                         new CommandBoost(this),
                         new CommandEditor(this),
                         new CommandSettings(this),

--- a/src/main/java/com/songoda/epicspawners/commands/CommandOpenShop.java
+++ b/src/main/java/com/songoda/epicspawners/commands/CommandOpenShop.java
@@ -26,7 +26,7 @@ public class CommandOpenShop extends AbstractCommand {
             return ReturnType.SYNTAX_ERROR;
         }
 
-        if (Bukkit.getPlayerExact(args[0]) == null && !args[0].toLowerCase().equals("all")) {
+        if (Bukkit.getPlayerExact(args[0]) == null && !args[0].equalsIgnoreCase("all")) {
             plugin.getLocale().newMessage("&cThat username does not exist, or the user is not online!").sendPrefixedMessage(sender);
             return ReturnType.FAILURE;
         }
@@ -36,7 +36,7 @@ public class CommandOpenShop extends AbstractCommand {
     }
 
     private void openShop(String who) {
-        if (who.toLowerCase().equals("all")) {
+        if (who.equalsIgnoreCase("all")) {
             for (Player pl : Bukkit.getOnlinePlayers()) {
                 plugin.getGuiManager().showGUI(pl, new SpawnerShopGui(plugin, pl));
             }

--- a/src/main/java/com/songoda/epicspawners/commands/CommandOpenShop.java
+++ b/src/main/java/com/songoda/epicspawners/commands/CommandOpenShop.java
@@ -1,0 +1,73 @@
+package com.songoda.epicspawners.commands;
+
+import com.songoda.core.commands.AbstractCommand;
+import com.songoda.epicspawners.EpicSpawners;
+import com.songoda.epicspawners.gui.SpawnerShopGui;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CommandOpenShop extends AbstractCommand {
+
+    private final EpicSpawners plugin;
+
+    public CommandOpenShop(EpicSpawners plugin) {
+        super(false, "openshop");
+        this.plugin = plugin;
+    }
+
+    @Override
+    protected ReturnType runCommand(CommandSender sender, String... args) {
+        if (args.length < 1 || args.length > 2) {
+            return ReturnType.SYNTAX_ERROR;
+        }
+
+        if (Bukkit.getPlayerExact(args[0]) == null && !args[0].toLowerCase().equals("all")) {
+            plugin.getLocale().newMessage("&cThat username does not exist, or the user is not online!").sendPrefixedMessage(sender);
+            return ReturnType.FAILURE;
+        }
+
+        this.openShop(args[0]);
+        return ReturnType.SUCCESS;
+    }
+
+    private void openShop(String who) {
+        if (who.toLowerCase().equals("all")) {
+            for (Player pl : Bukkit.getOnlinePlayers()) {
+                plugin.getGuiManager().showGUI(pl, new SpawnerShopGui(plugin, pl));
+            }
+        } else {
+            Player pl = Bukkit.getPlayerExact(who);
+            plugin.getGuiManager().showGUI(pl, new SpawnerShopGui(plugin, pl));
+        }
+    }
+
+    @Override
+    protected List<String> onTab(CommandSender sender, String... args) {
+        if (args.length == 1) {
+            List<String> players = Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toList());
+            players.add("All");
+            return players;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPermissionNode() {
+        return "epicspawners.admin.openshop";
+    }
+
+    @Override
+    public String getSyntax() {
+        return "openshop [player/all]";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Gives an operator the ability to open the spawner shop for someone.";
+    }
+}


### PR DESCRIPTION
Allow an operator to open the shop GUI for a player or to all players.

The permission for the command will be: epicspawners.admin.openshop

This command is useful if you don't want to allow a player to open `/spawnershop` and to attach the command `/es openshop <player>` to an NPC.
Please note that the command is better to not send a confirmation message so it can be used in the console, without spamming the console.