### PR TITLE
(Feat): Spawner upgrade cost now takes in account the stack size

### DIFF
--- a/EpicSpawners-Plugin/src/main/java/com/craftaro/epicspawners/gui/SpawnerOverviewGui.java
+++ b/EpicSpawners-Plugin/src/main/java/com/craftaro/epicspawners/gui/SpawnerOverviewGui.java
@@ -151,8 +151,8 @@ public class SpawnerOverviewGui extends CustomizableGui {
         itemmeta.setLore(lore);
         spawnerItem.setItemMeta(itemmeta);
 
-        double levelsCost = this.nextTier == null ? -1 : this.nextTier.getUpgradeCost(CostType.LEVELS);
-        double economyCost = this.nextTier == null ? -1 : this.nextTier.getUpgradeCost(CostType.ECONOMY);
+        double levelsCost = this.nextTier == null ? -1 : this.nextTier.getUpgradeCost(CostType.LEVELS) * this.spawner.getStackSize();
+        double economyCost = this.nextTier == null ? -1 : this.nextTier.getUpgradeCost(CostType.ECONOMY) * this.spawner.getStackSize();
 
         ItemStack itemLevels = Settings.XP_ICON.getMaterial().parseItem();
         ItemMeta itemmetaXP = itemLevels.getItemMeta();

--- a/EpicSpawners-Plugin/src/main/java/com/craftaro/epicspawners/spawners/spawner/SpawnerStackImpl.java
+++ b/EpicSpawners-Plugin/src/main/java/com/craftaro/epicspawners/spawners/spawner/SpawnerStackImpl.java
@@ -109,7 +109,7 @@ public class SpawnerStackImpl implements SpawnerStack {
         SpawnerTier tier = getSpawnerData().getNextTier(this.currentTier);
         SpawnerChangeEvent event = new SpawnerChangeEvent(player, this.spawner, tier, this.currentTier);
 
-        double cost = tier.getUpgradeCost(type);
+        double cost = tier.getUpgradeCost(type) * this.getSpawner().getStackSize();
         SpawnerTier oldTier = this.currentTier;
 
         if (type == CostType.ECONOMY) {


### PR DESCRIPTION
This will now consider the spawner stack size when calculating the correct cost for upgrading the spawner instead of just a stack size of one.

As you can see, it will now do $200,000 x 3 (stack size) = $600,000 instead of a flat rate of $200,000.
![image](https://github.com/craftaro/EpicSpawners/assets/55885015/912f9cc8-ed42-48e8-bf08-1c5938afce3f)
