### PR TITLE
Actually remove vanilla entity spawns from custom spawners

### DIFF
--- a/EpicSpawners-Plugin/src/main/java/com/craftaro/epicspawners/listeners/SpawnerListeners.java
+++ b/EpicSpawners-Plugin/src/main/java/com/craftaro/epicspawners/listeners/SpawnerListeners.java
@@ -13,7 +13,7 @@ import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
 import org.bukkit.event.entity.SpawnerSpawnEvent;
 
 public class SpawnerListeners implements Listener {
-    //@EventHandler
+    @EventHandler
     public void onSpawn(SpawnerSpawnEvent event) {
 
         //Respect vanilla spawners


### PR DESCRIPTION
This fixes a bug that allowed vanilla spawns to be produced from custom spawners (partially reverts commit 5c4a93b2f9d7bb79e8a9f3d471380a6146a83257).